### PR TITLE
Fix css mixin for placeholder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,7 @@
     "paper-checkbox": "PolymerElements/paper-checkbox/paper-checkbox#^2.0.2",
     "paper-button": "PolymerElements/paper-button/paper-button#^2.0.0",
     "paper-input": "PolymerElements/paper-input#^2.1.1",
-    "iron-icons": "PolymerElements/iron-icons#^2.0.1",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0"
+    "iron-icons": "PolymerElements/iron-icons#^2.0.1"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/mcd-multi-select.html
+++ b/mcd-multi-select.html
@@ -35,7 +35,7 @@ The following custom properties and mixins are available for styling:
 | Custom property | Description | Default |
 | --------------- | ----------- | ------- |
 | `--mcd-multi-select-selection` | Mixin applied to each selection of the selected items | {} |
-| `--mcd-multi-select-label ` | Mixin applied to label | {} |
+| `--mcd-multi-select-label` | Mixin applied to label | {} |
 | `--mcd-multi-select-placeholder` | Mixin applied to placeholder | {} |
 | `--mcd-multi-select-dismiss` | Mixin applied to the dismiss button | {} |
 | `--mcd-multi-select-dismiss-focus` | Mixin applied to the dismiss button when it is focused using the keyboard | {} |
@@ -264,7 +264,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         color: #545454;
         min-height: 18px;
         @apply --paper-font-subhead;
-        @apply --mcd-multi-select-label;
+        @apply --mcd-multi-select-placeholder;
       }
 
       #selectionsContainer .selection {


### PR DESCRIPTION
The --mcd-multi-select-label css mixin was used for both the label and the placeholder. Also the iron-demo-helpers should only be a dev dependency.