### PR TITLE
fix toggle all bug

### DIFF
--- a/mcd-multi-select.html
+++ b/mcd-multi-select.html
@@ -376,7 +376,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             /** Array of selected items made by the user */
             selectedItems: {
               type: Array,
-              value: []
+              value: [],
+              notify: true
             },
 
             /** Value used to filter data. */
@@ -490,7 +491,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
           if (this.selectedItems.length === this.items.length) {
             this.set("selectedItems", []);
           } else {
-            this.set("selectedItems", this.items);
+            this.set("selectedItems", [].concat(this.items));
           }
 
           if (this.filterValue != "") {


### PR DESCRIPTION
The property selectedItems will be replaced with items when toggle-all button clicked, which will be modified later. As a result, items passed in from parent element will be changed incidentally.